### PR TITLE
Upgrade Go 1.26.3, golangci-lint 2.12.2, crossplane-runtime v2.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       registry_org: rossigee
       mirror: false  # Disable mirroring to xpkg.upbound.io for rossigee registry
     secrets:
-      GHCR_PAT: ${{ secrets.PAT_TOKEN }}
+      GHCR_TOKEN: ${{ github.token }}
 
   # Create GitHub release with generated notes
   github-release:

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,15 @@ PLATFORMS ?= linux_amd64 linux_arm64
 -include build/makelib/output.mk
 
 # Setup Go
+GO_REQUIRED_VERSION = 1.26
+GOLANGCILINT_VERSION = 2.12.2
 NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
-# Override golangci-lint version for Go 1.25.3 support
-GOLANGCILINT_VERSION ?= 2.5.0
+
 -include build/makelib/golang.mk
 
 # Setup Kubernetes tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossigee/provider-cloudflare
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/cloudflare/cloudflare-go v0.116.0


### PR DESCRIPTION
Upgrade dependencies to:
- Go 1.26.3
- golangci-lint 2.12.2
- crossplane-runtime v2.3.1

This includes fixes for test file struct initialization patterns and deprecated webhook API usage.